### PR TITLE
Simplify translation of `call 0`/`jmp 0`/`call 5`/`jmp 5`

### DIFF
--- a/8088ify.c
+++ b/8088ify.c
@@ -710,10 +710,8 @@ call(void)
 
 	b = isbdos();
 	if (b == 1) {
-		fprintf(fq, "push\tax\n");
-		fprintf(fq, "\tmov\tah, cl\n");
-		fprintf(fq, "\tint\t21h\n");
-		fprintf(fq, "\tpop\tax");
+		fprintf(fq, "mov\tah, cl\n");
+		fprintf(fq, "\tint\t21h");
 	} else if (b == 2) {
 		fprintf(fq, "mov\tah, 4ch\n");
 		fprintf(fq, "\tint\t21h");
@@ -730,17 +728,12 @@ jmp(void)
 
 	b = isbdos();
 	if (b == 1) {
-		fprintf(fq, "push\tax\n");
-		fprintf(fq, "\tmov\tah, cl\n");
+		fprintf(fq, "mov\tah, cl\n");
 		fprintf(fq, "\tint\t21h\n");
-		fprintf(fq, "\tpop\tax\n");
 		fprintf(fq, "\tret");
 	} else if (b == 2) {
-		fprintf(fq, "mov\tcl, 0\n");
-		fprintf(fq, "\tmov\tdl, 0\n");
-		fprintf(fq, "\tmov\tah, 4ch\n");
-		fprintf(fq, "\tint\t21h\n");
-		fprintf(fq, "\tret");
+		fprintf(fq, "mov\tah, 4ch\n");
+		fprintf(fq, "\tint\t21h");
 	} else {
 		fprintf(fq, "jmp\t%s\n", a1);
 		fprintf(fq, "; WARN: Is the above jmp correct?");


### PR DESCRIPTION
Proposed changes:
  * I removed the `push ax` and `pop ax` surrounding each system call translated from `call 5`/`jmp 5`.  I believe this is more correct: some CP/M (and MS-DOS 1.x) syscalls return status codes in the `a` (or `al`) register, and `push ax` ... `pop ax` will destroy these.
  * There should be no need to set `cl` = `dl` = 0 when exiting the program via `int 0x21`, `ah` = `0x4c`.  The only parameter the syscall accepts is an exit status, which will come from `al`.
    * (An alternative might be to use `int 0x20` here, which will work on MS-DOS < 2.  Yet another alternative might be to simply leave `call 0` and `jmp 0` as-is.)

Thank you!